### PR TITLE
Add underscore to standard library header pattern

### DIFF
--- a/cmake-init/templates/common/.clang-format
+++ b/cmake-init/templates/common/.clang-format
@@ -73,7 +73,7 @@ ForEachMacros:
 IncludeBlocks: Regroup
 IncludeCategories:{if cpp}
   # Standard library headers come before anything else
-  - Regex: '^<[a-z]+>'
+  - Regex: '^<[a-z_]+>'
     Priority: -1{end}
   - Regex: '^<.+\.h{if cpp}(pp)?{end}>'
     Priority: 1{if cpp}


### PR DESCRIPTION
Some headers, like string_view and unordered_map, have underscores. This groups them with other standard headers.

<!--
Please make sure your Pull Request is targeting the develop branch.
-->
