### PR TITLE
Update git version search for Apple Git

### DIFF
--- a/cmake-init/cmake_init.py
+++ b/cmake-init/cmake_init.py
@@ -237,12 +237,17 @@ def write_dir(path, d, overwrite, zip_path):
 
 
 def determine_git_version():
+    search_pattern = r"\d+(\.\d+)+"
     git_version_out = \
         subprocess.run("git --version", shell=True, capture_output=True)
     if git_version_out.returncode != 0:
         return None
-    git_version_str = str(git_version_out.stdout[12:], sys.stdout.encoding)
-    git_version = list(map(int, git_version_str.rstrip().split(".")[:3]))
+    git_version_out = str(git_version_out.stdout, sys.stdout.encoding)
+    git_version_match = re.search(search_pattern, git_version_out)
+    if not git_version_match:
+        return None
+    git_version_str = git_version_match.group(0)
+    git_version = list(map(int, git_version_str.rstrip().split(".")))
     if len(git_version) < 3:
         git_version += [0] * (3 - len(git_version))
     return tuple(git_version)


### PR DESCRIPTION
When running `cmake-init` on macOS Catalina with Apple Git installed, the following error is raised: 

`ValueError: invalid literal for int() with base 10: '1 (Apple Git-122'`.

Running `git --version` yields: `git version 2.21.1 (Apple Git-122.3)`

This PR updates the `determine_git_version()` method to use regex to match the first valid version string from the output of `git --version`.

Testing this on various possible strings:

```python
strings = [
    "git version 2.21.1 (Apple Git-122.3)",
    "git version 2.21.1.windows.0",
    "git version 2.21.1",
    "git version 2.21",
    "git version 0",
]
```

yields:

```
(2, 21, 1)
(2, 21, 1)
(2, 21, 1)
(2, 21, 0)
None
```


