### PR TITLE
Exclude 3rd-party directory from coverage

### DIFF
--- a/cmake-init/templates/common/cmake/coverage.cmake
+++ b/cmake-init/templates/common/cmake/coverage.cmake
@@ -8,6 +8,7 @@ set(
     -o "${PROJECT_BINARY_DIR}/coverage.info"
     -d "${PROJECT_BINARY_DIR}"
     --include "${PROJECT_SOURCE_DIR}/*"
+    --exclude "${FETCHCONTENT_BASE_DIR}/*"
     CACHE STRING
     "; separated command to generate a trace for the 'coverage' target"
 )


### PR DESCRIPTION
When using FetchContent_Declare with coverage, this also included 3rd-party libs in the coverage report.

Old coverage report:
![Screenshot_20220706_112159](https://user-images.githubusercontent.com/28039927/177517544-23778605-f84a-4a43-98e3-b18b64145da7.png)

New coverage report:
![Screenshot_20220706_112241](https://user-images.githubusercontent.com/28039927/177517599-dce1d53a-1380-44ba-bb6e-a33c39d79ec6.png)

Tested with this project: https://github.com/bensuperpc/vector

**Update**:

I might also add:
`--exclude "${PROJECT_SOURCE_DIR}/test/*"`
To avoid including the tests in the coverage.

For this result:
![Screenshot_20220706_132146](https://user-images.githubusercontent.com/28039927/177539108-ce3e6fe3-8eac-491e-9852-f13f4e71bbc3.png)

![Screenshot_20220706_132200](https://user-images.githubusercontent.com/28039927/177539137-31245ff2-6f78-4a86-9d64-4b9d59ec2464.png)

