### PR TITLE
Get catch2 as build requirement with host config

### DIFF
--- a/cmake-init/templates/common/conanfile.py
+++ b/cmake-init/templates/common/conanfile.py
@@ -16,6 +16,6 @@ class Recipe(ConanFile):
         self.requires("json-c/0.15"){% else %}
         self.requires("fmt/9.0.0"){% end %}
 
-        # Testing only dependencies below{% if catch3 %}
-        self.requires("catch2/3.0.1"){% else %}
-        self.requires("catch2/2.13.9"){% end %}
+    def build_requirements(self):{% if catch3 %}
+        self.test_requires("catch2/3.0.1"){% else %}
+        self.test_requires("catch2/2.13.9"){% end %}


### PR DESCRIPTION
The build_requirements method is better suitable for test framework
dependencies because tests are only relevant during a package build
from sources and provide no good use in delivered packages.
Relevant documentation links:
https://docs.conan.io/en/latest/reference/conanfile/methods.html#build-requirements
https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html#requirements

<!--
Please make sure your Pull Request is targeting the develop branch.

Please make sure your commit messages conform to the checks contained in
.github/scripts/lint-commits.js.
-->
