### PR TITLE
Update install-rules.cmake

### DIFF
--- a/cmake-init/templates/common/BUILDING.md
+++ b/cmake-init/templates/common/BUILDING.md
@@ -80,7 +80,12 @@ target_link_libraries(
 )
 ```
 
-### Creating a VCPKG port
+### Note to packagers
+If you wish to expose your library as a package, you should carefully review how 
+`CMAKE_INSTALL_INCLUDEDIR` is set, as the default behavior might not match your
+package mangagers expectations.
+
+#### Creating a vcpkg port
 If you wish to expose your package on vcpkg the following `portfile.cmake`
 
 ```cmake
@@ -107,7 +112,9 @@ vcpkg_cmake_config_fixup()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" 
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" 
+     RENAME copyright)
 ```
 
 {% end %}

--- a/cmake-init/templates/common/BUILDING.md
+++ b/cmake-init/templates/common/BUILDING.md
@@ -79,6 +79,37 @@ target_link_libraries(
     {= name =}::{= name =}
 )
 ```
+
+### Creating a VCPKG port
+If you wish to expose your package on vcpkg the following `portfile.cmake`
+
+```cmake
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO <org_name/repo_name>
+  REF <insert git ref here>
+  HEAD_REF master
+  SHA512 <insert sha here>
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+  "-DCMAKE_INSTALL_INCLUDEDIR=${CURRENT_PACKAGES_DIR}/include"
+)
+
+vcpkg_cmake_build()
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+```
+
 {% end %}
 [1]: https://cmake.org/download/
 [2]: https://cmake.org/cmake/help/latest/manual/cmake.1.html#install-a-project{% if not exe %}

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,6 +1,7 @@
 {% if not exe %}if(PROJECT_IS_TOP_LEVEL)
-  # CMAKE_INSTALL_INCLUDEDIR is nested in one more ${PROJECT_VERSION} directory to prevent inclusion of all other headers in the install prefix directory.
-  #   See https://github.com/friendlyanon/cmake-init/issues/43 for more info
+  # CMAKE_INSTALL_INCLUDEDIR is nested in one more "{= name =}-${PROJECT_VERSION}"
+  # directory to prevent direct inclusion of headers from other libraries 
+  # which share the prefix directory.
   set(CMAKE_INSTALL_INCLUDEDIR "include/{= name =}-${PROJECT_VERSION}" CACHE PATH "")
 endif(){% if header %}
 

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,5 +1,5 @@
 {% if not exe %}if(PROJECT_IS_TOP_LEVEL)
-  set(CMAKE_INSTALL_INCLUDEDIR include/{= name =}-${CMAKE_PROJECT_VERSION} CACHE PATH "")
+  set(CMAKE_INSTALL_INCLUDEDIR "include/{= name =}-${PROJECT_VERSION}" CACHE PATH "")
 endif(){% if header %}
 
 # Project is configured with no languages, so tell GNUInstallDirs the lib dir

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,7 +1,3 @@
-{% if not exe %}if(PROJECT_IS_TOP_LEVEL)
-  set(CMAKE_INSTALL_INCLUDEDIR include/{= name =} CACHE PATH "")
-endif(){% if header %}
-
 # Project is configured with no languages, so tell GNUInstallDirs the lib dir
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH ""){% end %}
 

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,4 +1,10 @@
 # Project is configured with no languages, so tell GNUInstallDirs the lib dir
+{% if not exe %}if(PROJECT_IS_TOP_LEVEL)
+  set(CMAKE_INSTALL_INCLUDEDIR include/{= name =}-${CMAKE_PROJECT_VERSION} CACHE PATH "")
+endif(){% if header %}
+
+
+
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH ""){% end %}
 
 include(CMakePackageConfigHelpers)

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,4 +1,6 @@
 {% if not exe %}if(PROJECT_IS_TOP_LEVEL)
+  # CMAKE_INSTALL_INCLUDEDIR is nested in one more ${PROJECT_VERSION} directory to prevent inclusion of all other headers in the install prefix directory.
+  #   See https://github.com/friendlyanon/cmake-init/issues/43 for more info
   set(CMAKE_INSTALL_INCLUDEDIR "include/{= name =}-${PROJECT_VERSION}" CACHE PATH "")
 endif(){% if header %}
 

--- a/cmake-init/templates/common/cmake/install-rules.cmake
+++ b/cmake-init/templates/common/cmake/install-rules.cmake
@@ -1,10 +1,8 @@
-# Project is configured with no languages, so tell GNUInstallDirs the lib dir
 {% if not exe %}if(PROJECT_IS_TOP_LEVEL)
   set(CMAKE_INSTALL_INCLUDEDIR include/{= name =}-${CMAKE_PROJECT_VERSION} CACHE PATH "")
 endif(){% if header %}
 
-
-
+# Project is configured with no languages, so tell GNUInstallDirs the lib dir
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH ""){% end %}
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
The current install-rules double indent the include folder: as in `installation_prefix/include/libname/libname/header.hpp`. At least when running: `cmake --install build_folder_path --prefix=./installation_prefix`

Removing these three lines seems to be a better default behavior. When we tried to get our library on vcpkg, this was an issue which blocked us from merging.

<!--
Please make sure your commit messages conform to the checks contained in
.github/scripts/lint-commits.js.
-->
