### PR TITLE
Adding support for both Release and Debug conan configs

### DIFF
--- a/cmake-init/templates/common/BUILDING.md
+++ b/cmake-init/templates/common/BUILDING.md
@@ -4,6 +4,17 @@
 
 For a list of dependencies, please refer to {% if vcpkg %}[vcpkg.json](vcpkg.json){% else %}[conanfile.py](conanfile.py){% end %}.{% end %}
 
+{% if pm_name=="conan" %}
+### Installing Conan Dependencies
+From the project root, run the following command:
+
+```sh
+conan install . -sbuild_type=<BUILD_TYPE> --build=missing
+```
+
+Where `<BUILD_TYPE>` is either `Release` or `Debug`.
+{% end %}
+
 ## Build
 
 This project doesn't require any special command-line flags to build to keep

--- a/cmake-init/templates/common/CMakePresets.json
+++ b/cmake-init/templates/common/CMakePresets.json
@@ -45,10 +45,18 @@
       }
     },{% end %}{% if conan %}
     {
-      "name": "conan",
+      "name": "conan-dev",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/conan/conan_toolchain.cmake",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/conan/debug/conan_toolchain.cmake",
+        "CMAKE_POLICY_DEFAULT_CMP0091": "NEW"
+      }
+    },
+    {
+      "name": "conan-rel",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/conan/release/conan_toolchain.cmake",
         "CMAKE_POLICY_DEFAULT_CMP0091": "NEW"
       }
     },{% end %}
@@ -131,7 +139,11 @@
     },
     {
       "name": "ci-coverage",
-      "inherits": ["coverage-unix", "dev-mode"{% if pm %}, "{= pm_name =}"{% end %}],
+      "inherits": [
+        "coverage-unix",
+        "dev-mode"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% end %}
+      ],
       "cacheVariables": {
         "COVERAGE_HTML_COMMAND": ""
       }
@@ -139,7 +151,11 @@
     {
       "name": "ci-sanitize",
       "binaryDir": "${sourceDir}/build/sanitize",
-      "inherits": ["ci-unix", "dev-mode"{% if pm %}, "{= pm_name =}"{% end %}],
+      "inherits": [
+        "ci-unix",
+        "dev-mode"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% end %}
+      ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Sanitize",
         "CMAKE_C{% if cpp %}XX{% end %}_FLAGS_SANITIZE": "-O2 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-common"{% if c and pm %},
@@ -154,15 +170,32 @@
     },
     {
       "name": "ci-macos",
-      "inherits": ["ci-build", "ci-unix", "dev-mode"{% if pm %}, "{= pm_name =}"{% end %}]
+      "inherits": [
+        "ci-build",
+        "ci-unix",
+        "dev-mode"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% end %}
+      ]
     },
     {
       "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-unix", "clang-tidy"{% if pm %}, "{= pm_name =}"{% end %}, "cppcheck", "dev-mode"]
+      "inherits": [
+        "ci-build",
+        "ci-unix",
+        "clang-tidy"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% end %},
+        "cppcheck",
+        "dev-mode"]
     },
     {
       "name": "ci-windows",
-      "inherits": ["ci-build", "ci-win64", "dev-mode"{% if pm %}, "{= pm_name =}"{% if vcpkg %}, "vcpkg-win64-static"{% end %}{% end %}]
+      "inherits": [
+        "ci-build",
+        "ci-win64",
+        "dev-mode"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% if vcpkg %},
+        "vcpkg-win64-static"{% end %}{% end %}
+      ]
     }
   ]
 }

--- a/cmake-init/templates/common/CMakeUserPresets.json
+++ b/cmake-init/templates/common/CMakeUserPresets.json
@@ -9,7 +9,25 @@
     {
       "name": "dev-common",
       "hidden": true,
-      "inherits": ["dev-mode"{% if pm %}, "{= pm_name =}"{% end %}{% if use_clang_tidy %}, "clang-tidy"{% end %}{% if use_cppcheck %}, "cppcheck"{% end %}],
+      "inherits": [
+        "dev-mode"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-dev{% end %}"{% end %}{% if use_clang_tidy %},
+        "clang-tidy"{% end %}{% if use_cppcheck %},
+        "cppcheck"{% end %}
+      ],
+      "cacheVariables": {
+        "BUILD_MCSS_DOCS": "ON"
+      }
+    },
+    {
+      "name": "rel-common",
+      "hidden": true,
+      "inherits": [
+        "ci-unix"{% if pm %},
+        "{= pm_name =}{% if pm_name=="conan" %}-rel{% end %}"{% end %}{% if use_clang_tidy %},
+        "clang-tidy"{% end %}{% if use_cppcheck %},
+        "cppcheck"{% end %}
+      ],
       "cacheVariables": {
         "BUILD_MCSS_DOCS": "ON"
       }
@@ -41,6 +59,15 @@
       "name": "dev-coverage",
       "binaryDir": "${sourceDir}/build/coverage",
       "inherits": ["dev-mode", "coverage-unix"{% if pm %}, "{= pm_name =}"{% end %}]
+    },
+    {
+      "name": "rel",
+      "binaryDir": "${sourceDir}/build/rel",
+      "inherits": "rel-common",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
     }
   ],
   "buildPresets": [

--- a/cmake-init/templates/common/conanfile.py
+++ b/cmake-init/templates/common/conanfile.py
@@ -9,7 +9,10 @@ class Recipe(ConanFile):
     }{% end %}
 
     def layout(self):
-        self.folders.generators = "conan"
+        if (self.settings.build_type == "Release"):
+            self.folders.generators = "conan/release"
+        else:
+            self.folders.generators = "conan/debug"
 
     def requirements(self):{% if c %}{% if exe %}
         self.requires("hedley/15"){% end %}


### PR DESCRIPTION
When trying out `cmake-init` with Conan, I realised that switching between `release` and `debug` Conan builds would be a bit of a pain as it installs all the Conan cmake config files in the same directory `${sourceDir}/conan`. Check [this comment](https://github.com/friendlyanon/cmake-init/issues/77#issuecomment-1373401786) for the idea behind it.

This PR makes the user preset `rel` for release building, and also adds `conan-dev` and `conan-rel` with different toolchain locations. 

TODO : I should probably change the docs too in this PR.