### PR TITLE
Add .clangd file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,0 @@
-CompileFlags:
-  CompilationDatabase: ./build/dev/

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: ./build/dev/

--- a/cmake-init/templates/common/.clangd
+++ b/cmake-init/templates/common/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/dev


### PR DESCRIPTION
I've added a default `.clangd` compilation database for people who might be using `clangd` directly as their LSP, for example from `vim`/`neovim`. The default `dev` profile will export the compile commands by default, so I think it makes sense to point the default CompilationDatabase to that directory as well.