### PR TITLE
Update language standard for C and C++

### DIFF
--- a/cmake-init/cmake_init.py
+++ b/cmake-init/cmake_init.py
@@ -50,9 +50,9 @@ class Language:
         return self.name
 
 
-c_lang = Language("C", ["e", "s", "h"], ["90", "99", "11"], 1)
+c_lang = Language("C", ["e", "s", "h"], ["90", "99", "11", "23"], 1)
 
-cpp_lang = Language("C++", ["e", "h", "s"], ["11", "14", "17", "20"], 2)
+cpp_lang = Language("C++", ["e", "h", "s"], ["11", "14", "17", "20", "23"], 2)
 
 
 def not_empty(value):


### PR DESCRIPTION
By now, most compilers support C++23, and even C23.

See

- [Compiler support C23](https://en.cppreference.com/w/c/compiler_support/23) and [CMAKE_C_KNOWN_FEATURES](https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_C_KNOWN_FEATURES.html)
- [Compiler support C++23](https://en.cppreference.com/w/cpp/compiler_support/23) and [CMAKE_CXX_KNOWN_FEATURES](https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html)

For this to work the **CMake version has to be bumped to at least 3.21**, though.