### PR TITLE
Changed default branch to main for new projects

### DIFF
--- a/cmake-init/cmake_init.py
+++ b/cmake-init/cmake_init.py
@@ -320,7 +320,7 @@ def git_init(cwd):
         return
     branch = ""
     if (2, 28, 0) <= git_version:
-        branch = " -b master"
+        branch = " -b main"
     subprocess.run(f"git init{branch}", shell=True, check=True, cwd=cwd)
     print("""
 The project is ready to be used with git. If you are using GitHub, you may
@@ -329,7 +329,7 @@ push the project with the following commands from the project directory:
     git add .
     git commit -m "Initial commit"
     git remote add origin https://github.com/<your-account>/<repository>.git
-    git push -u origin master
+    git push -u origin main
 """)
 
 

--- a/cmake-init/templates/common/.github/workflows/ci.yml
+++ b/cmake-init/templates/common/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - master
+    - main
 
   pull_request:
     branches:
-    - master{% if vcpkg %}
+    - main{% if vcpkg %}
 
 env:
   VCPKG_COMMIT: "16ee2ecb31788c336ace8bb14c21801efb6836e4"{% end %}
@@ -217,7 +217,7 @@ jobs:
     # this comment and the last line in the conditional below.
     # If you do not wish to use GitHub Pages for deploying documentation, then
     # simply delete this job similarly to the coverage one.
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
       && github.event_name == 'push'
       && github.repository_owner == '<name>'
       && false

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$(git branch --show-current)" = master ]; then
+if [ "$(git branch --show-current)" = main ]; then
   MAIN=cmake-init/cmake_init.py
   VERSION="v$(grep -oP '^__version__ = "\K\d(\.\d+){2}' "${MAIN}")"
   if [ -n "$(git ls-remote --tags origin "${VERSION}")" ]; then


### PR DESCRIPTION
Changed the default branch of the initialized repository from "master" to "main" to adhere to github default behavior. 