### PR TITLE
Suppress additional targets added by CTest

### DIFF
--- a/cmake-init/templates/common/cmake/dev-mode.cmake
+++ b/cmake-init/templates/common/cmake/dev-mode.cmake
@@ -1,5 +1,6 @@
 include(cmake/folders.cmake)
 
+set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 include(CTest)
 if(BUILD_TESTING)
   add_subdirectory(test)


### PR DESCRIPTION
CTest inclusion by default adds a bunch of targets.
Adding before the inclusion `set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)` suppresses them.