### PR TITLE
Fix codespell false positive when comment follows #include <stdio.h>

### DIFF
--- a/cmake-init/templates/common/.codespellrc
+++ b/cmake-init/templates/common/.codespellrc
@@ -4,4 +4,4 @@ check-filenames =
 check-hidden =
 skip = */.git,*/build,*/prefix{% if conan %},*/conan{% end %}{% if c %},*/.codespellrc{% end %}
 quiet-level = 2{% if c %}
-ignore-regex = ^#include <(?:stdio)\.h>${% end %}
+ignore-regex = ^#include <(?:stdio)\.h>(\s*//.*)?${% end %}


### PR DESCRIPTION
Fix .codespellrc so that comments after #include <stdio.h> don't trigger a false positive of misspelled studio