### PR TITLE
include C++23 standard

### DIFF
--- a/cmake-init/cmake_init.py
+++ b/cmake-init/cmake_init.py
@@ -50,7 +50,7 @@ class Language:
 
 c_lang = Language("C", ["e", "s", "h"], ["90", "99", "11", "17", "23"], 1)
 
-cpp_lang = Language("C++", ["e", "h", "s"], ["11", "14", "17", "20"], 2)
+cpp_lang = Language("C++", ["e", "h", "s"], ["11", "14", "17", "20", "23"], 2)
 
 
 def not_empty(value):


### PR DESCRIPTION
copilot summary because its a simple change:
This pull request updates the `cpp_lang` initialization in the `cmake-init/cmake_init.py` file to include support for the C++23 standard.

* [`cmake-init/cmake_init.py`](diffhunk://#diff-b6cfe1f3dcbab63065e80f5ba45a8b0fff615b3bade9d239c61bf49628bda3a9L53-R53): Added "23" to the list of supported standards for the `cpp_lang` object, extending compatibility to C++23.